### PR TITLE
Add the ability to pull configuration options from the environment.

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -83,6 +83,7 @@ typedef struct {
     int vimgrep;
     int word_regexp;
     int workers;
+    int ignore_environment;
 } cli_options;
 
 /* global options. parse_options gives it sane values, everything else reads from it */
@@ -94,7 +95,14 @@ void usage(void);
 void print_version(void);
 
 void init_options(void);
+void environment_options(int argc, char **argv);
 void parse_options(int argc, char **argv, char **base_paths[], char **paths[]);
 void cleanup_options(void);
 
+int env_int_option(const char *name, int *var);
+int env_bool_option(const char *name, int *var);
+size_t env_size_option(const char *name, size_t *var);
+const char *env_string_option(const char *name, char **var);
+const char *env_color_option(const char *name, char **var);
+void replace_color(char **color, char *val);
 #endif

--- a/tests/environment.t
+++ b/tests/environment.t
@@ -1,0 +1,40 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ echo Foo > ./sample
+  $ echo bar >> ./sample
+  $ echo baz >> ./sample
+
+Context (int) from AG_CONTEXT
+
+  $ AG_CONTEXT=1 ag bar sample
+  1-Foo
+  2:bar
+  3-baz
+
+Before (size_t) from AG_BEFORE
+
+  $ AG_BEFORE=1 ag bar sample
+  1-Foo
+  2:bar
+
+Line numbers (boolean, false) from AG_LINE_NUMBERS
+
+  $ AG_LINE_NUMBERS=false ag bar sample
+  bar
+
+Whole word matching (boolean, true) from AG_WHOLE_WORD
+
+  $ echo barr >> ./sample
+  $ AG_WHOLE_WORD=1 ag bar sample
+  2:bar
+
+Case matching (string) from AG_CASE
+
+  $ AG_CASE=insensitive ag fOO sample
+  1:Foo
+
+Match color from AG_COLOR_MATCH
+
+  $ AG_COLOR_MATCH=30\;41 ag --color --no-numbers Foo sample
+  \x1b[30;41mFoo\x1b[0m\x1b[K (esc)

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -2,3 +2,9 @@
 # of ag we just built, and make the output really simple.
 
 alias ag="$TESTDIR/../ag --nocolor --workers=1 --parallel"
+
+# Ignore the user's environment, which might change default behaviors
+# export AG_IGNORE_ENVIRONMENT=true
+
+# Instead, remove the variables from the environment
+eval `env | egrep '^AG_' | sed -e 's/^\([^=]*\)=.*/unset \1/'`


### PR DESCRIPTION
Many of the command-line options now also have environment variables.

Also added a command-line option (and environment variable) to ignore the environment for configuration.

In the case of a boolean configuration, environment variables set without a value currently do not affect the value, but it would be easy enough to change that. (I am currently embroiled in a long argument with myself about how they should be handled.)

I am open to any comments you might have but especially the names of the functions and environment variables.

Along the way, I noticed that `opts.before` & `opts.after` are both `size_t`, whereas `opts.context` is an `int`. I don’t think there is any value to a negative context, and I may open a separate issue/PR for that, since context is the only reason for the `env_int_option` function.
